### PR TITLE
Call Nest CLI directly in dev script

### DIFF
--- a/apps/api-gateway/package.json
+++ b/apps/api-gateway/package.json
@@ -9,7 +9,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "start:dev": "pnpm exec nest start --watch",
+    "start:dev": "node node_modules/@nestjs/cli/bin/nest.js start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",


### PR DESCRIPTION
## Summary
- call the Nest CLI via its local node binary so the dev command works in Docker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d74d4bb108832b8208db49c9e4c762