### PR TITLE
Add environment example files for services and web app

### DIFF
--- a/apps/api-gateway/.env.example
+++ b/apps/api-gateway/.env.example
@@ -1,0 +1,6 @@
+# Copie este arquivo para .env antes de subir os containers.
+NODE_ENV=development
+PORT=3001
+SWAGGER_ENABLED=true
+RATE_LIMIT_WINDOW_MS=1000
+RATE_LIMIT_MAX=10

--- a/apps/auth-service/.env.example
+++ b/apps/auth-service/.env.example
@@ -1,0 +1,6 @@
+# Copie este arquivo para .env antes de subir os containers.
+NODE_ENV=development
+PORT=3002
+DATABASE_URL=postgres://postgres:password@db:5432/challenge_db
+JWT_ACCESS_SECRET=changeme
+JWT_REFRESH_SECRET=changeme

--- a/apps/notifications-service/.env.example
+++ b/apps/notifications-service/.env.example
@@ -1,0 +1,5 @@
+# Copie este arquivo para .env antes de subir os containers.
+NODE_ENV=development
+PORT=3004
+DATABASE_URL=postgres://postgres:password@db:5432/challenge_db
+RABBITMQ_URL=amqp://admin:admin@rabbitmq:5672

--- a/apps/tasks-service/.env.example
+++ b/apps/tasks-service/.env.example
@@ -1,0 +1,5 @@
+# Copie este arquivo para .env antes de subir os containers.
+NODE_ENV=development
+PORT=3003
+DATABASE_URL=postgres://postgres:password@db:5432/challenge_db
+RABBITMQ_URL=amqp://admin:admin@rabbitmq:5672

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,3 @@
+# Copie este arquivo para .env.local antes de subir os containers.
+VITE_API_URL=http://localhost:3001/api
+VITE_WS_URL=ws://localhost:3001/ws


### PR DESCRIPTION
## Summary
- document default configuration for the API Gateway environment template
- add essential placeholders for the auth, tasks, and notifications services
- provide frontend environment example pointing to the API gateway endpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d75b19b450832b9d1ac93910069d86