### PR TITLE
Add shared health response type

### DIFF
--- a/apps/api-gateway/src/health/health.controller.ts
+++ b/apps/api-gateway/src/health/health.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
+import { HealthResponse } from '@repo/types';
 
 @Controller('health')
 export class HealthController {
   @Get()
-  ok() {
-    return { status: 'ok' };
+  ok(): HealthResponse {
+    return { status: 'ok', uptime: process.uptime() };
   }
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -35,3 +35,8 @@ export interface CommentDTO {
   body: string;
   createdAt: string;
 }
+
+export interface HealthResponse {
+  status: "ok";
+  uptime?: number;
+}


### PR DESCRIPTION
## Summary
- export a shared `HealthResponse` interface from the types package
- update the API gateway health controller to use the shared response type and include uptime data

## Testing
- pnpm -F @repo/types typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d75bc84224832baf9b8c773d81797b