### PR TITLE
fix: register rabbitmq client in auth module

### DIFF
--- a/apps/api-gateway/src/app.module.ts
+++ b/apps/api-gateway/src/app.module.ts
@@ -4,8 +4,6 @@ import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
 import { HealthModule } from './health/health.module';
 import { AuthModule } from './auth/auth.module';
-import { ClientsModule, Transport } from '@nestjs/microservices';
-import { AUTH_SERVICE_RABBITMQ } from './auth/consts';
 
 function msToSeconds(ms: number) {
   return Math.max(1, Math.floor(ms / 1000));
@@ -20,19 +18,6 @@ const limit = parseInt(process.env.RATE_LIMIT_MAX ?? '10', 10);
     ThrottlerModule.forRoot([{ ttl: msToSeconds(windowMs), limit }]),
     HealthModule,
     AuthModule,
-    ClientsModule.register([
-      {
-        name: AUTH_SERVICE_RABBITMQ,
-        transport: Transport.RMQ,
-        options: {
-          urls: ['amqp://admin:admin@localhost:5672'],
-          queue: 'auth_queue',
-          queueOptions: {
-            durable: true,
-          },
-        },
-      }
-    ])
   ],
   providers: [
     {

--- a/apps/api-gateway/src/auth/auth.module.ts
+++ b/apps/api-gateway/src/auth/auth.module.ts
@@ -1,8 +1,25 @@
 import { Module } from '@nestjs/common';
+import { ClientsModule, Transport } from '@nestjs/microservices';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
+import { AUTH_SERVICE_RABBITMQ } from './consts';
 
 @Module({
+  imports: [
+    ClientsModule.register([
+      {
+        name: AUTH_SERVICE_RABBITMQ,
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://admin:admin@localhost:5672'],
+          queue: 'auth_queue',
+          queueOptions: {
+            durable: true,
+          },
+        },
+      },
+    ]),
+  ],
   controllers: [AuthController],
   providers: [AuthService],
 })


### PR DESCRIPTION
## Summary
- register the AUTH_SERVICE_RABBITMQ client inside the AuthModule so Nest can inject it
- remove the redundant ClientsModule registration from the AppModule

## Testing
- pnpm --filter @apps/api-gateway lint *(fails: Cannot find package '@repo/eslint-config')*


------
https://chatgpt.com/codex/tasks/task_e_68d804facbcc832b872272efd5c06085