### PR TITLE
Add HTTP request examples for auth gateway

### DIFF
--- a/apps/api-gateway/requests.http
+++ b/apps/api-gateway/requests.http
@@ -1,0 +1,11 @@
+@baseUrl = http://localhost:3001/api
+
+### Login with an existing user
+POST {{baseUrl}}/auth/login
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "player@example.com",
+  "password": "SuperSecurePassword123"
+}


### PR DESCRIPTION
## Summary
- add an HTTP request collection for the API Gateway auth controller
- document the login endpoint with sample payload

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d807b650c8832b94866504da1f4e82